### PR TITLE
fix(codegen): strip bare-path first line from untagged fences (#38)

### DIFF
--- a/codegen/artifact.py
+++ b/codegen/artifact.py
@@ -96,6 +96,36 @@ def _strip_file_marker(body: str) -> str:
     return rest if (sep and _FILE_MARKER_RE.match(first)) else body
 
 
+def _strip_leading_path_marker(body: str, resolved_path: str) -> str:
+    """Drop a leading bare-path line from a block body when it equals the
+    resolved path. This is the gemma4:12b shape surfaced by conduct#38:
+
+        ```rust
+        src/lib.rs
+        pub fn ...   <- actual source
+        ```
+
+    The fence is untagged, so the path is inferred from language convention
+    (or a preceding bold/backtick path). The model then ALSO echoes the path
+    as the body's first line, which — unlike the ``// file:`` / ``# file:``
+    marker — has no comment prefix, so the existing :func:`_strip_file_marker`
+    leaves it in place and rustc fails on ``src/lib.rs:1:4: expected one of
+    `!` or `::`, found `/` ``.
+
+    The strip is gated on the first line matching ``resolved_path`` exactly
+    so we never mangle source code whose first line merely looks like a
+    path. Comparison is whitespace-trimmed on both sides to absorb the
+    ``**path**`` / `` `path` `` bolding that sometimes survives into the
+    body when the model wraps the marker line in markdown emphasis.
+    """
+    if not resolved_path:
+        return body
+    first, sep, rest = body.partition("\n")
+    if not sep:
+        return body
+    return rest if first.strip() == resolved_path else body
+
+
 def _loads_tolerant(blob: str, max_fixes: int = 16):
     """json.loads, but tolerant of trailing commas — a very common LLM-JSON
     quirk (``{"a": 1,}``). On a decode error we look at the exact offending
@@ -176,7 +206,14 @@ def _extract_fenced_files(text: str) -> dict[str, str]:
         )
         if path is None:
             continue
-        files[path] = _strip_file_marker(body)
+        # Strip order: first any ``// file:`` / ``# file:`` marker (comment-style),
+        # then a leading bare path that matches the resolved path (the gemma4:12b
+        # untagged-fence shape from conduct#38). The second strip is gated on
+        # equality with the path we just inferred so it can't mangle a source
+        # whose first line merely happens to look like a path.
+        content = _strip_file_marker(body)
+        content = _strip_leading_path_marker(content, path)
+        files[path] = content
     return files
 
 

--- a/tests/unit/test_codegen_artifact.py
+++ b/tests/unit/test_codegen_artifact.py
@@ -101,6 +101,49 @@ def test_explicit_path_beats_convention() -> None:
     assert set(files) == {"Cargo.toml", "src/thing.rs"}
 
 
+def test_untagged_rust_with_bare_path_first_line_lib() -> None:
+    # conduct#38: gemma4:12b emits an untagged ```rust fence whose first line
+    # is the bare path "src/lib.rs". Without stripping, that line ends up as
+    # line 1 of the source and rustc fails with "expected one of `!` or `::`,
+    # found `/`". The conventional-path inference already resolves the path;
+    # the body's leading path marker must be stripped.
+    # The fence regex consumes the trailing \n before the closing ```, so the
+    # body has no trailing newline once it's been captured.
+    lib_body = "src/lib.rs\npub fn whatever() -> usize { 1 }"
+    text = f"```toml\n{_CARGO}```\n```rust\n{lib_body}```\n"
+    files = parse_cargo_project(text)
+    assert set(files) == {"Cargo.toml", "src/lib.rs"}
+    assert files["src/lib.rs"] == "pub fn whatever() -> usize { 1 }"
+    # The path marker must not leak into the stored source.
+    assert files["src/lib.rs"].splitlines()[0] == "pub fn whatever() -> usize { 1 }"
+
+
+def test_untagged_rust_with_bare_path_first_line_main() -> None:
+    # Same shape as the lib variant but with fn main — the conventional-path
+    # fallback picks src/main.rs (via the fn-main detector) and the leading
+    # bare path line still needs to be stripped.
+    main_body = "src/main.rs\nfn main() { println!(\"hi\"); }"
+    text = f"```toml\n{_CARGO}```\n```rust\n{main_body}```\n"
+    files = parse_cargo_project(text)
+    assert set(files) == {"Cargo.toml", "src/main.rs"}
+    assert files["src/main.rs"] == "fn main() { println!(\"hi\"); }"
+    assert files["src/main.rs"].splitlines()[0] == "fn main() { println!(\"hi\"); }"
+
+
+def test_untagged_fence_path_marker_only_stripped_when_matches_resolved() -> None:
+    # Defensive: a leading line that LOOKS like a path but doesn't match the
+    # resolved path must NOT be stripped (it might be real code).
+    # Here the fence resolves to src/lib.rs (no fn main); the body's first line
+    # is "src/main.rs" which is a different path and must be preserved.
+    body = "src/main.rs\npub fn kept() {}"
+    text = f"```toml\n{_CARGO}```\n```rust\n{body}```\n"
+    files = parse_cargo_project(text)
+    assert set(files) == {"Cargo.toml", "src/lib.rs"}
+    # The body was stored verbatim — the line that happened to look like a
+    # path but didn't match the resolved path stayed.
+    assert files["src/lib.rs"] == body
+
+
 def test_lone_rust_snippet_fails_on_missing_cargo() -> None:
     # A bare ```rust snippet becomes src/lib.rs by convention, then fails for
     # lack of a Cargo.toml — still a structured failure, not a crash.


### PR DESCRIPTION
Fixes #38.

## What was broken

After the conduct#36 parser-robustness work, untagged fences get their path inferred from the language tag alone (```toml -> Cargo.toml; ```rust with fn main -> src/main.rs; otherwise src/lib.rs). gemma4:12b then echoes that path back as the first line of the body, so the body literally becomes:

    src/lib.rs
    pub fn whatever() -> usize { 1 }

The existing _strip_file_marker only handles the "// file: <path>" / "# file: <path>" comment-prefixed shape, so this bare-path first line was written to disk verbatim. rustc fails on it:

    src/lib.rs:1:4: error: expected one of `!` or `::`, found `/`

Per the bench-v2 evidence in #38, 6 of 10 gemma4:12b specs failed compile with this identical error before any real evaluation could run -- so the head-to-head with gemma4:e4b on the bigger-12b variant is currently unmeasurable.

## Fix

New helper _strip_leading_path_marker(body, resolved_path) in codegen/artifact.py. After a fence has been assigned a path (by info, body marker, preceding line, or conventional-path inference), also drop the body first line when it equals that resolved path -- and only when it equals it. The equality gate is the important guardrail: a leading line that merely looks like a path (but is not the one we resolved to) must be left alone, since it could be real code.

The strip is wired into _extract_fenced_files right after the existing _strip_file_marker call -- comment-style markers are stripped first, then the bare-path shape.

## Tests

Three new cases in tests/unit/test_codegen_artifact.py:

- test_untagged_rust_with_bare_path_first_line_lib -- the exact shape from #38 (untagged rust fence, first line "src/lib.rs"). Asserts the marker line is stripped and the real source starts on line 1.
- test_untagged_rust_with_bare_path_first_line_main -- same shape with fn main -> src/main.rs. Confirms the fn-main detector in _conventional_path still picks the right path and the strip still runs.
- test_untagged_fence_path_marker_only_stripped_when_matches_resolved -- defensive guardrail: a first line that looks like a path but does not match the resolved path is NOT stripped (could be real code).

All 28 unit tests pass (25 baseline + 3 new).

## Diff summary

codegen/artifact.py +38/-1 (new helper + 7-line wiring in _extract_fenced_files)
tests/unit/test_codegen_artifact.py +43/-0 (three new regression tests)